### PR TITLE
Support nested configurations

### DIFF
--- a/lib/app_config.ex
+++ b/lib/app_config.ex
@@ -119,8 +119,8 @@ defmodule AppConfig do
   @doc """
   Returns a tuple with the value for `key` in an application's environment,
   in a keyword list or in the OS environment. The first argument can either be
-  an atom with the name of the application or a keyword list with the different
-  configuration values.
+  an atom with the name of the application, a keyword list or a map with the
+  different configuration values.
 
   ## Returns
 
@@ -135,7 +135,7 @@ defmodule AppConfig do
 
   """
   @spec fetch_env(app | Keyword.t, key) :: {:ok, value} | :error
-  def fetch_env(env, key) when (is_atom(env) or is_list(env)) and is_atom(key) do
+  def fetch_env(env, key) when (is_atom(env) or is_list(env) or is_map(env)) and is_atom(key) do
     with {:ok, value} <- fetch(env, key) do
       get_env_value(value)
     end
@@ -146,6 +146,9 @@ defmodule AppConfig do
   end
   defp fetch(list, key) when is_list(list) do
     Keyword.fetch(list, key)
+  end
+  defp fetch(map, key) when is_map(map) do
+    Map.fetch(map, key)
   end
 
   @doc """

--- a/test/app_config_test.exs
+++ b/test/app_config_test.exs
@@ -37,6 +37,18 @@ defmodule AppConfigTest do
     assert %ArgumentError{} = catch_error(AppConfig.fetch_env!(env, :unknown_var))
   end
 
+  test "value from map" do
+    test_val = "12345"
+    env = %{dummy1: "ABC", test_var: test_val, dummy2: "DEF"}
+    assert {:ok, test_val} == AppConfig.fetch_env(env, :test_var)
+    assert :error == AppConfig.fetch_env(env, :unknown_var)
+    assert test_val == AppConfig.get_env(env, :test_var)
+    assert 12345 == AppConfig.get_env_integer(env, :test_var)
+    assert nil == AppConfig.get_env(env, :unknown_var)
+    assert test_val == AppConfig.fetch_env!(env, :test_var)
+    assert %ArgumentError{} = catch_error(AppConfig.fetch_env!(env, :unknown_var))
+  end
+
   test "value from system environment" do
     env_var = "TEST_VAR"
     test_val = "12345"

--- a/test/app_config_test.exs
+++ b/test/app_config_test.exs
@@ -13,6 +13,22 @@ defmodule AppConfigTest do
 
   doctest AppConfig
 
+  test "nested value from application environment" do
+    test_val = "12345"
+    test_val_nested = %{map_key: [kw_key: test_val]}
+    :ok = Application.put_env(:my_test_app, :env_key, test_val_nested)
+    assert {:ok, test_val} == MyTestApp.fetch_env([:env_key, :map_key, :kw_key])
+    assert :error == MyTestApp.fetch_env([:unknown_var])
+    assert :error == MyTestApp.fetch_env([:env_key, :unknown_var])
+    assert :error == MyTestApp.fetch_env([:env_key, :map_key, :unknown_var])
+    assert :error == MyTestApp.fetch_env([:env_key, :map_key, :kw_key, :extra_key])
+    assert test_val == MyTestApp.get_env([:env_key, :map_key, :kw_key])
+    assert nil == MyTestApp.get_env([:env_key, :map_key, :kw_key, :extra_key])
+    assert 12345 == MyTestApp.get_env_integer([:env_key, :map_key, :kw_key])
+    assert test_val == MyTestApp.fetch_env!([:env_key, :map_key, :kw_key])
+    assert %ArgumentError{} = catch_error(MyTestApp.fetch_env!([:env_key, :map_key, :kw_key, :extra_key]))
+  end
+
   test "value from application environment" do
     test_val = "12345"
     :ok = Application.put_env(:my_test_app, :test_var, test_val)


### PR DESCRIPTION
Add support for nested configurations to allow fetching values in a hierarchical structure.

Adds support for Map.fetch in addition to Application.fetch_env and Keyword.fetch.