### PR TITLE
Avoid redefining built-in type specification

### DIFF
--- a/lib/app_config.ex
+++ b/lib/app_config.ex
@@ -98,7 +98,6 @@ defmodule AppConfig do
   @type app :: Application.app
   @type key :: Application.key | [Application.key]
   @type value :: Application.value
-  @type var :: String.t
 
   @doc false
   defmacro __using__(opts) do
@@ -208,7 +207,7 @@ defmodule AppConfig do
       {:ok, "VALUE"}
 
   """
-  @spec get_env_value({:system, var} | {:system, var, String.t} | term)
+  @spec get_env_value({:system, String.t} | {:system, String.t, String.t} | term)
     :: {:ok, term} | :error
   def get_env_value({:system, var}) do
     case System.get_env(var) do


### PR DESCRIPTION
When compiling `app_config` with Elixir `1.8.1` and Erlang OTP `21.1` I get the following error:
```
==> app_config
Compiling 1 file (.ex)

== Compilation error in file lib/app_config.ex ==
** (CompileError) lib/app_config.ex:101: type var/0 is a built-in type and it cannot be redefined
    (elixir) lib/kernel/typespec.ex:891: Kernel.Typespec.compile_error/2
    (elixir) lib/kernel/typespec.ex:243: anonymous fn/2 in Kernel.Typespec.collect_defined_type_pairs/1
    (stdlib) lists.erl:1263: :lists.foldl/3
    (elixir) lib/kernel/typespec.ex:213: Kernel.Typespec.translate_typespecs_for_module/2
    (stdlib) erl_eval.erl:680: :erl_eval.do_apply/6
```

This PR fixes this error by using the primitive `String.t` typespec directly instead.